### PR TITLE
TRA index page: Update Himawari Design links

### DIFF
--- a/tra/index.html
+++ b/tra/index.html
@@ -33,7 +33,8 @@
 		On 2017-03-22, Kuururi Ahojanen from Himawari Design in Japan made a new map. It's much better. Please use his. 
 		
 		<br>
-			<a href="http://www.47rail.jp/#area-9" target=_blank>http://www.47rail.jp</a>
+			<a href="http://www.47rail.jp/routemap.html#Area-9" target=_blank>http://www.47rail.jp</a> |
+			<a href="http://www.47rail.jp/data/routemap_taiwan_201910_web.pdf">(PDF)</a>
 		</br>		
 		
 		<h3>


### PR DESCRIPTION
Hi! Came across your TRA map while researching the system. Seems like the 47rail.jp site has been restructured at least once in the past few years, so my PR has a more targeted permalink.

Thanks!